### PR TITLE
Enable mock MongoDB for analytics service

### DIFF
--- a/code/manufactoring-analytics/requirements.txt
+++ b/code/manufactoring-analytics/requirements.txt
@@ -7,3 +7,4 @@ python-dateutil==2.8.2
 pytz==2023.3
 Werkzeug==2.3.7
 gunicorn==21.2.0
+mongomock==4.1.2

--- a/code/manufactoring-analytics/src/manufacturing_analytics.py
+++ b/code/manufactoring-analytics/src/manufacturing_analytics.py
@@ -3,15 +3,31 @@ import pandas as pd
 import numpy as np
 from datetime import datetime, timedelta
 from pymongo import MongoClient
+import mongomock
 from typing import List, Dict, Any
 import csv
 import json
 from collections import defaultdict
 
 class ManufacturingAnalytics:
-    def __init__(self, mongo_uri: str, database_name: str):
-        """Initialize the analytics service with MongoDB connection"""
-        self.client = MongoClient(mongo_uri)
+    def __init__(self, mongo_uri: str, database_name: str, use_mock: bool = False):
+        """Initialize the analytics service with MongoDB connection.
+        If ``use_mock`` is True or the connection fails and the ``USE_MOCK_MONGO``
+        environment variable is set, an in-memory MongoDB instance is used.
+        """
+
+        if use_mock:
+            self.client = mongomock.MongoClient()
+        else:
+            try:
+                self.client = MongoClient(mongo_uri, serverSelectionTimeoutMS=2000)
+                # Trigger connection to validate
+                self.client.server_info()
+            except Exception:
+                if os.environ.get("USE_MOCK_MONGO", "false").lower() == "true":
+                    self.client = mongomock.MongoClient()
+                else:
+                    raise
         self.db = self.client[database_name]
         self.orders_collection = self.db['NewOrder']
         self.machines_collection = self.db['macchinari']
@@ -90,7 +106,10 @@ class ManufacturingAnalytics:
             current_queue_length = len(machine.get('tablet', []))
             
             # Filter phases for this machine
-            machine_phases = phase_df[phase_df['phase_name'] == machine_name]
+            if 'phase_name' in phase_df.columns:
+                machine_phases = phase_df[phase_df['phase_name'] == machine_name]
+            else:
+                machine_phases = pd.DataFrame()
             
             if len(machine_phases) > 0:
                 metrics = {
@@ -175,6 +194,13 @@ class ManufacturingAnalytics:
     
     def generate_queue_analysis(self, phase_df: pd.DataFrame) -> pd.DataFrame:
         """Analyze queue patterns and bottlenecks"""
+        if phase_df.empty or 'phase_name' not in phase_df.columns:
+            return pd.DataFrame(columns=[
+                'phase_name', 'avg_queue_delay', 'queue_delay_std',
+                'max_queue_delay', 'total_jobs', 'total_quantity',
+                'is_bottleneck']
+            )
+
         # Group by machine and calculate queue metrics
         queue_metrics = phase_df.groupby('phase_name').agg({
             'queue_delay_hours': ['mean', 'std', 'max'],
@@ -197,7 +223,7 @@ class ManufacturingAnalytics:
         
         # Split operator strings and create individual records
         for _, row in phase_df.iterrows():
-            if row['operators']:
+            if 'operators' in row and row['operators']:
                 operators = row['operators'].split(',')
                 for operator in operators:
                     operator = operator.strip()
@@ -265,12 +291,18 @@ class ManufacturingAnalytics:
             'completed_orders': len([o for o in orders if o.get('orderStatus', {}).get('$numberInt') == '4']),
             'active_machines': len([m for m in machines if m.get('macchinarioActive', False)]),
             'total_machines': len(machines),
-            'avg_order_lead_time': order_timeline['lead_time_days'].mean(),
-            'on_time_delivery_rate': (order_timeline['on_time'].sum() / len(order_timeline[order_timeline['on_time'].notna()]) * 100) if len(order_timeline[order_timeline['on_time'].notna()]) > 0 else 0,
-            'avg_machine_utilization': machine_metrics['utilization_percentage'].mean(),
-            'avg_machine_efficiency': machine_metrics['efficiency_percentage'].mean(),
+            'avg_order_lead_time': order_timeline['lead_time_days'].mean() if 'lead_time_days' in order_timeline else None,
+            'on_time_delivery_rate': (
+                order_timeline['on_time'].sum() / len(order_timeline[order_timeline['on_time'].notna()]) * 100
+            ) if 'on_time' in order_timeline and len(order_timeline[order_timeline['on_time'].notna()]) > 0 else 0,
+            'avg_machine_utilization': machine_metrics['utilization_percentage'].mean() if 'utilization_percentage' in machine_metrics else None,
+            'avg_machine_efficiency': machine_metrics['efficiency_percentage'].mean() if 'efficiency_percentage' in machine_metrics else None,
             'total_operators': len(operator_performance) if len(operator_performance) > 0 else 0,
-            'bottleneck_machines': queue_analysis[queue_analysis['is_bottleneck']]['phase_name'].tolist()
+            'bottleneck_machines': (
+                queue_analysis.loc[queue_analysis['is_bottleneck'], 'phase_name'].tolist()
+                if 'phase_name' in queue_analysis.columns and 'is_bottleneck' in queue_analysis.columns
+                else []
+            )
         }
         
         with open(f'{output_dir}/summary_statistics.json', 'w') as f:

--- a/code/manufactoring-analytics/src/microservice_scheduler.py
+++ b/code/manufactoring-analytics/src/microservice_scheduler.py
@@ -53,10 +53,14 @@ def handle_errors(f):
     return decorated_function
 
 def initialize_analytics():
-    """Initialize analytics service with error handling"""
+    """Initialize analytics service with error handling.
+    If the ``USE_MOCK_MONGO`` environment variable is set to ``true`` the
+    service will use an in-memory MongoDB instance.
+    """
     global analytics
     try:
-        analytics = ManufacturingAnalytics(MONGO_URI, DATABASE_NAME)
+        use_mock = os.environ.get('USE_MOCK_MONGO', 'false').lower() == 'true'
+        analytics = ManufacturingAnalytics(MONGO_URI, DATABASE_NAME, use_mock)
         logger.info("Analytics service initialized successfully")
         return True
     except Exception as e:


### PR DESCRIPTION
## Summary
- allow falling back to an in-memory MongoDB using `mongomock`
- handle empty datasets in analytics calculations
- document the mock setup in `initialize_analytics`
- add `mongomock` to requirements

## Testing
- `python -m py_compile code/manufactoring-analytics/src/*.py`
- `USE_MOCK_MONGO=true python code/manufactoring-analytics/src/microservice_scheduler.py` then `curl http://127.0.0.1:5000/health`

------
https://chatgpt.com/codex/tasks/task_e_6841a90fb0d4832f93c2b1580c7807de